### PR TITLE
Modeling: Organizers should be able to approve/reject claims

### DIFF
--- a/spec/Organization/Controller/ClaimControllerSpec.php
+++ b/spec/Organization/Controller/ClaimControllerSpec.php
@@ -80,4 +80,14 @@ class ClaimControllerSpec extends ObjectBehavior
 
         $this->shouldThrow(\Exception::class)->during('approvePendingClaim', [$pendingClaim]);
     }
+
+    public function it_allows_organizer_to_reject_pending_claim(EntityManager $entityManager, ClaimEntity $pendingClaim)
+    {
+        $pendingClaim->markAsRejected()->shouldBeCalled();
+
+        $entityManager->persist($pendingClaim)->shouldBeCalled();
+        $entityManager->flush()->shouldBeCalled();
+
+        $this->rejectPendingClaim($pendingClaim)->shouldReturn($pendingClaim);
+    }
 }

--- a/spec/Organization/Controller/ClaimControllerSpec.php
+++ b/spec/Organization/Controller/ClaimControllerSpec.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace spec\Organization\Controller;
+
+use Doctrine\ORM\EntityManager;
+use Organization\Controller\ClaimController;
+use Organization\Entity\ClaimEntity;
+use Organization\Entity\OrganizationEntity;
+use Organization\Repository\ClaimRepository;
+use PhpSpec\ObjectBehavior;
+use Talk\Entity\TalkEntity;
+use User\Entity\UserEntity;
+
+class ClaimControllerSpec extends ObjectBehavior
+{
+    public function let(ClaimRepository $claimRepository, EntityManager $entityManager, UserEntity $currentUser)
+    {
+        $this->beConstructedWith($claimRepository, $entityManager, $currentUser);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(ClaimController::class);
+    }
+
+    public function it_shows_all_pending_claims_to_organizer(
+        ClaimRepository $claimRepository,
+        OrganizationEntity $organization,
+        ClaimEntity $pendingClaim1
+    ) {
+        $claimRepository
+            ->findOrganizationsPendingClaims($organization)
+            ->shouldBeCalled()
+            ->willReturn([$pendingClaim1]);
+
+        $this->showPendingClaims($organization)->shouldReturn([$pendingClaim1]);
+    }
+
+    public function it_allows_organizer_to_approve_pending_claim(
+        EntityManager $entityManager,
+        UserEntity $currentUser,
+        ClaimEntity $pendingClaim,
+        TalkEntity $talk,
+        UserEntity $speaker,
+        OrganizationEntity $organization
+    ) {
+        $pendingClaim->getSpeaker()->shouldBeCalled()->willReturn($speaker);
+        $pendingClaim->getTalk()->shouldBeCalled()->willReturn($talk);
+
+        $talk->getOrganization()->shouldBeCalled()->willReturn($organization);
+
+        $organization->isOrganizer($currentUser)
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $pendingClaim->markAsApproved()->shouldBeCalled();
+
+        $talk->setSpeaker($speaker)->shouldBeCalled();
+
+        $entityManager->persist($pendingClaim)->shouldBeCalled();
+        $entityManager->persist($talk)->shouldBeCalled();
+        $entityManager->flush()->shouldBeCalled();
+
+        $this->approvePendingClaim($pendingClaim)->shouldReturn($pendingClaim);
+    }
+
+    public function it_disallows_non_organizer_to_approve_pending_claim(
+        UserEntity $currentUser,
+        ClaimEntity $pendingClaim,
+        TalkEntity $talk,
+        OrganizationEntity $organization
+    ) {
+        $pendingClaim->getTalk()->shouldBeCalled()->willReturn($talk);
+
+        $talk->getOrganization()->shouldBeCalled()->willReturn($organization);
+
+        $organization->isOrganizer($currentUser)
+            ->shouldBeCalled()
+            ->willReturn(false);
+
+        $this->shouldThrow(\Exception::class)->during('approvePendingClaim', [$pendingClaim]);
+    }
+}

--- a/spec/Organization/Entity/ClaimEntitySpec.php
+++ b/spec/Organization/Entity/ClaimEntitySpec.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace spec\Organization\Entity;
+
+use Organization\Entity\ClaimEntity;
+use PhpSpec\ObjectBehavior;
+use Talk\Entity\TalkEntity;
+use User\Entity\UserEntity;
+
+class ClaimEntitySpec extends ObjectBehavior
+{
+    public function let(TalkEntity $talk, UserEntity $speaker)
+    {
+        $this->beConstructedWith($talk, $speaker);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(ClaimEntity::class);
+    }
+
+    public function it_can_expose_talk(TalkEntity $talk)
+    {
+        $this->getTalk()->shouldReturn($talk);
+    }
+
+    public function it_can_expose_speaker(UserEntity $speaker)
+    {
+        $this->getSpeaker()->shouldReturn($speaker);
+    }
+}

--- a/spec/Organization/Entity/MeetupEntitySpec.php
+++ b/spec/Organization/Entity/MeetupEntitySpec.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace spec\Organization\Entity;
+
+use Organization\Entity\MeetupEntity;
+use PhpSpec\ObjectBehavior;
+
+class MeetupEntitySpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(MeetupEntity::class);
+    }
+}

--- a/spec/Organization/Entity/OrganizationEntitySpec.php
+++ b/spec/Organization/Entity/OrganizationEntitySpec.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace spec\Organization\Entity;
+
+use Organization\Entity\OrganizationEntity;
+use PhpSpec\ObjectBehavior;
+
+class OrganizationEntitySpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(OrganizationEntity::class);
+    }
+}

--- a/spec/Organization/Repository/ClaimRepositorySpec.php
+++ b/spec/Organization/Repository/ClaimRepositorySpec.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace spec\Organization\Repository;
+
+use Organization\Repository\ClaimRepository;
+use PhpSpec\ObjectBehavior;
+
+class ClaimRepositorySpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(ClaimRepository::class);
+    }
+}

--- a/spec/Talk/Entity/TalkEntitySpec.php
+++ b/spec/Talk/Entity/TalkEntitySpec.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace spec\Talk\Entity;
+
+use Organization\Entity\MeetupEntity;
+use PhpSpec\ObjectBehavior;
+use Talk\Entity\TalkEntity;
+use User\Entity\UserEntity;
+
+class TalkEntitySpec extends ObjectBehavior
+{
+    public function let(MeetupEntity $meetup)
+    {
+        $this->beConstructedWith(
+            $meetup,
+            $title = 'Title of the talk',
+            $description = 'Very very long text',
+            $speakerName = 'John Doe'
+        );
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(TalkEntity::class);
+    }
+
+    public function it_exposes_meetup_it_belongs_to(MeetupEntity $meetup)
+    {
+        $this->getMeetup()->shouldReturn($meetup);
+    }
+
+    public function it_exposes_speaker_name()
+    {
+        $this->getSpeakerName()->shouldReturn('John Doe');
+    }
+
+    public function it_exposes_speaker_name_from_speaker_when_set(UserEntity $speaker)
+    {
+        $speaker->getName()->shouldBeCalled()->willReturn('John Travolta');
+        $this->setSpeaker($speaker);
+
+        $this->getSpeakerName()->shouldReturn('John Travolta');
+    }
+}

--- a/spec/User/Entity/UserEntitySpec.php
+++ b/spec/User/Entity/UserEntitySpec.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace spec\User\Entity;
+
+use PhpSpec\ObjectBehavior;
+use User\Entity\UserEntity;
+
+class UserEntitySpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(UserEntity::class);
+    }
+}

--- a/src/Organization/Controller/ClaimController.php
+++ b/src/Organization/Controller/ClaimController.php
@@ -54,4 +54,14 @@ class ClaimController
 
         return $claim;
     }
+
+    public function rejectPendingClaim(ClaimEntity $claim)
+    {
+        $claim->markAsRejected();
+
+        $this->entityManager->persist($claim);
+        $this->entityManager->flush();
+
+        return $claim;
+    }
 }

--- a/src/Organization/Controller/ClaimController.php
+++ b/src/Organization/Controller/ClaimController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Organization\Controller;
+
+use Doctrine\ORM\EntityManager;
+use Organization\Entity\ClaimEntity;
+use Organization\Entity\OrganizationEntity;
+use Organization\Repository\ClaimRepository;
+use User\Entity\UserEntity;
+
+class ClaimController
+{
+    /** @var ClaimRepository */
+    private $claimRepository;
+    /** @var EntityManager */
+    private $entityManager;
+    /**
+     * @var UserEntity
+     */
+    private $currentUser;
+
+    public function __construct(ClaimRepository $claimRepository, EntityManager $entityManager, UserEntity $currentUser)
+    {
+        $this->claimRepository = $claimRepository;
+        $this->entityManager   = $entityManager;
+        $this->currentUser     = $currentUser;
+    }
+
+    public function showPendingClaims(OrganizationEntity $organization)
+    {
+        $pendingClaims = $this->claimRepository->findOrganizationsPendingClaims($organization);
+
+        return $pendingClaims;
+    }
+
+    public function approvePendingClaim(ClaimEntity $claim)
+    {
+        $talk         = $claim->getTalk();
+        $organization = $talk->getOrganization();
+
+        if (false === $organization->isOrganizer($this->currentUser)) {
+            throw new \Exception('NOT ALLOWED');
+        }
+
+        $claim->markAsApproved();
+
+        $speaker = $claim->getSpeaker();
+
+        $talk->setSpeaker($speaker);
+
+        $this->entityManager->persist($claim);
+        $this->entityManager->persist($talk);
+        $this->entityManager->flush();
+
+        return $claim;
+    }
+}

--- a/src/Organization/Entity/ClaimEntity.php
+++ b/src/Organization/Entity/ClaimEntity.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Organization\Entity;
+
+use Talk\Entity\TalkEntity;
+use User\Entity\UserEntity;
+
+class ClaimEntity
+{
+    /** @var TalkEntity */
+    private $talk;
+    /** @var UserEntity */
+    private $speaker;
+    /** @var bool */
+    private $approved = null;
+
+    public function __construct(TalkEntity $talk, UserEntity $speaker)
+    {
+        // TODO: write logic here
+        $this->talk    = $talk;
+        $this->speaker = $speaker;
+    }
+
+    public function getTalk(): TalkEntity
+    {
+        return $this->talk;
+    }
+
+    public function getSpeaker(): UserEntity
+    {
+        return $this->speaker;
+    }
+
+    public function markAsApproved()
+    {
+        $this->approved = true;
+    }
+}

--- a/src/Organization/Entity/ClaimEntity.php
+++ b/src/Organization/Entity/ClaimEntity.php
@@ -35,4 +35,9 @@ class ClaimEntity
     {
         $this->approved = true;
     }
+
+    public function markAsRejected()
+    {
+        $this->approved = false;
+    }
 }

--- a/src/Organization/Entity/MeetupEntity.php
+++ b/src/Organization/Entity/MeetupEntity.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Organization\Entity;
+
+class MeetupEntity
+{
+    public function getOrganization(): OrganizationEntity
+    {
+        //@TODO;
+    }
+}

--- a/src/Organization/Entity/OrganizationEntity.php
+++ b/src/Organization/Entity/OrganizationEntity.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Organization\Entity;
+
+use User\Entity\UserEntity;
+
+class OrganizationEntity
+{
+    public function isOrganizer(UserEntity $user): bool
+    {
+        //@TODO;
+    }
+}

--- a/src/Organization/Entity/OrganizationEntity.php
+++ b/src/Organization/Entity/OrganizationEntity.php
@@ -6,6 +6,7 @@ use User\Entity\UserEntity;
 
 class OrganizationEntity
 {
+    /** @SuppressWarnings("PHPMD.UnusedFormalParameter") */
     public function isOrganizer(UserEntity $user): bool
     {
         //@TODO;

--- a/src/Organization/Repository/ClaimRepository.php
+++ b/src/Organization/Repository/ClaimRepository.php
@@ -6,6 +6,7 @@ use Organization\Entity\OrganizationEntity;
 
 class ClaimRepository
 {
+    /** @SuppressWarnings("PHPMD.UnusedFormalParameter") */
     public function findOrganizationsPendingClaims(OrganizationEntity $organization)
     {
         //@TODO;

--- a/src/Organization/Repository/ClaimRepository.php
+++ b/src/Organization/Repository/ClaimRepository.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Organization\Repository;
+
+use Organization\Entity\OrganizationEntity;
+
+class ClaimRepository
+{
+    public function findOrganizationsPendingClaims(OrganizationEntity $organization)
+    {
+        //@TODO;
+    }
+}

--- a/src/Talk/Entity/TalkEntity.php
+++ b/src/Talk/Entity/TalkEntity.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Talk\Entity;
+
+use Organization\Entity\MeetupEntity;
+use Organization\Entity\OrganizationEntity;
+use User\Entity\UserEntity;
+
+class TalkEntity
+{
+    /** @var MeetupEntity */
+    private $meetup;
+    /**
+     * @var string
+     */
+    private $title;
+    /**
+     * @var string
+     */
+    private $description;
+    /**
+     * @var string
+     */
+    private $speakerName;
+    /**
+     * @var UserEntity|null
+     */
+    private $speaker;
+
+    public function __construct(
+        MeetupEntity $meetup,
+        string $title,
+        string $description,
+        string $speakerName
+    ) {
+        $this->meetup      = $meetup;
+        $this->title       = $title;
+        $this->description = $description;
+        $this->speakerName = $speakerName;
+    }
+
+    public function setSpeaker(UserEntity $speaker)
+    {
+        $this->speaker = $speaker;
+    }
+
+    public function getMeetup(): MeetupEntity
+    {
+        return $this->meetup;
+    }
+
+    public function getOrganization(): OrganizationEntity
+    {
+        //@TODO
+    }
+
+    public function getSpeakerName()
+    {
+        if (null !== $this->speaker) {
+            return $this->speaker->getName();
+        }
+
+        return $this->speakerName;
+    }
+}

--- a/src/User/Entity/UserEntity.php
+++ b/src/User/Entity/UserEntity.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace User\Entity;
+
+class UserEntity
+{
+    public function getName(): string
+    {
+        //@TODO
+    }
+}


### PR DESCRIPTION
First part of our modelling session today was approving/rejecting claims from speakers.

This is the code we did on workshop and will be continuing with it next time. 

Part of #26