### PR TITLE
Replace Zend\EventManager\Exception\DomainException with DomainException

### DIFF
--- a/src/Event/Controller/EventController.php
+++ b/src/Event/Controller/EventController.php
@@ -3,10 +3,10 @@
 namespace Event\Controller;
 
 use Doctrine\ORM\EntityManager;
+use DomainException;
 use Event\Entity\EventEntity;
 use Organization\Entity\OrganizationEntity;
 use User\Entity\UserEntity;
-use Zend\EventManager\Exception\DomainException;
 
 class EventController
 {


### PR DESCRIPTION
By mistake, we used Zend\EventManager\Exception\DomainException when modelling

Closes #55