### PR TITLE
Feature #32 - Speaker can edit Talk

### DIFF
--- a/spec/Talk/Entity/TalkEntitySpec.php
+++ b/spec/Talk/Entity/TalkEntitySpec.php
@@ -41,4 +41,26 @@ class TalkEntitySpec extends ObjectBehavior
 
         $this->getSpeakerName()->shouldReturn('John Travolta');
     }
+
+    public function it_exposes_talk_title()
+    {
+        $this->getTitle()->shouldReturn('Title of the talk');
+    }
+
+    public function it_can_change_talk_title()
+    {
+        $this->changeTitle('New title for old talk');
+        $this->getTitle()->shouldReturn('New title for old talk');
+    }
+
+    public function it_exposes_talk_description()
+    {
+        $this->getDescription()->shouldReturn('Very very long text');
+    }
+
+    public function it_can_change_talk_description()
+    {
+        $this->changeDescription('A bit shorter long text');
+        $this->getDescription()->shouldReturn('A bit shorter long text');
+    }
 }

--- a/src/Talk/Entity/TalkEntity.php
+++ b/src/Talk/Entity/TalkEntity.php
@@ -67,4 +67,24 @@ class TalkEntity
 
         return $this->speakerName;
     }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function changeTitle(string $talkTitle): void
+    {
+        $this->title = $talkTitle;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function changeDescription(string $talkDescription): void
+    {
+        $this->description = $talkDescription;
+    }
 }


### PR DESCRIPTION
This is ~still a WIP, but I'd like your opinions and ideas on how to approach this~ a base to continue work on issue #32 with [Behat scenarios (@leovujanic)](https://github.com/NullTraining/reviewz/pull/74).

Please see [issue discussing editing talk details](https://github.com/NullTraining/reviewz/issues/32) for reference and clarification.

