### PR TITLE
Fix tests namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "App\\Tests\\": "tests/",
+            "Tests\\": "tests/",
             "spec\\": "spec/"
         }
     },


### PR DESCRIPTION
By mistake, we left 'App/Tests' as root namespace in composer