### PR TITLE
Enforce strict types

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -6,9 +6,11 @@ $finder = PhpCsFixer\Finder::create()
     ->in('tests');
 
 return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
     ->setRules(array(
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
+        'declare_strict_types' => true,
         'binary_operator_spaces' => [
             'default' => 'align_single_space_minimal',
         ],

--- a/spec/Event/Controller/EventControllerSpec.php
+++ b/spec/Event/Controller/EventControllerSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Event\Controller;
 
 use DateTime;

--- a/spec/Event/Entity/EventEntitySpec.php
+++ b/spec/Event/Entity/EventEntitySpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Event\Entity;
 
 use DateTime;

--- a/spec/Event/Entity/EventIdSpec.php
+++ b/spec/Event/Entity/EventIdSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Event\Entity;
 
 use Event\Entity\EventId;

--- a/spec/Geo/Entity/CityEntitySpec.php
+++ b/spec/Geo/Entity/CityEntitySpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Geo\Entity;
 
 use Geo\Entity\CityEntity;

--- a/spec/Geo/Entity/CityIdSpec.php
+++ b/spec/Geo/Entity/CityIdSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Geo\Entity;
 
 use Geo\Entity\CityId;

--- a/spec/Geo/Entity/CountryEntitySpec.php
+++ b/spec/Geo/Entity/CountryEntitySpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Geo\Entity;
 
 use Geo\Entity\CountryEntity;

--- a/spec/Geo/Entity/LocationEntitySpec.php
+++ b/spec/Geo/Entity/LocationEntitySpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Geo\Entity;
 
 use Geo\Entity\CityEntity;

--- a/spec/Geo/Entity/LocationIdSpec.php
+++ b/spec/Geo/Entity/LocationIdSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Geo\Entity;
 
 use Geo\Entity\LocationId;

--- a/spec/Organization/Command/JoinOrganizationSpec.php
+++ b/spec/Organization/Command/JoinOrganizationSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Organization\Command;
 
 use Organization\Command\JoinOrganization;

--- a/spec/Organization/Controller/ClaimControllerSpec.php
+++ b/spec/Organization/Controller/ClaimControllerSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Organization\Controller;
 
 use Doctrine\ORM\EntityManager;

--- a/spec/Organization/Controller/OrganizationControllerSpec.php
+++ b/spec/Organization/Controller/OrganizationControllerSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Organization\Controller;
 
 use Doctrine\ORM\EntityManager;

--- a/spec/Organization/Controller/RsvpControllerSpec.php
+++ b/spec/Organization/Controller/RsvpControllerSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Organization\Controller;
 
 use Doctrine\ORM\EntityManager;

--- a/spec/Organization/Entity/ClaimEntitySpec.php
+++ b/spec/Organization/Entity/ClaimEntitySpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Organization\Entity;
 
 use Organization\Entity\ClaimEntity;

--- a/spec/Organization/Entity/ClaimIdSpec.php
+++ b/spec/Organization/Entity/ClaimIdSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Organization\Entity;
 
 use Organization\Entity\ClaimId;

--- a/spec/Organization/Entity/OrganizationEntitySpec.php
+++ b/spec/Organization/Entity/OrganizationEntitySpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Organization\Entity;
 
 use DomainException;

--- a/spec/Organization/Handler/JoinOrganizationHandlerSpec.php
+++ b/spec/Organization/Handler/JoinOrganizationHandlerSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Organization\Handler;
 
 use Organization\Command\JoinOrganization;

--- a/spec/Organization/Repository/ClaimRepositorySpec.php
+++ b/spec/Organization/Repository/ClaimRepositorySpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Organization\Repository;
 
 use Organization\Repository\ClaimRepository;

--- a/spec/Talk/Commmand/ClaimTalkSpec.php
+++ b/spec/Talk/Commmand/ClaimTalkSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Talk\Commmand;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/Talk/Controller/TalkControllerSpec.php
+++ b/spec/Talk/Controller/TalkControllerSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Talk\Controller;
 
 use Doctrine\ORM\EntityManager;

--- a/spec/Talk/Entity/FeedbackEntitySpec.php
+++ b/spec/Talk/Entity/FeedbackEntitySpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Talk\Entity;
 
 use DateTime;

--- a/spec/Talk/Entity/FeedbackIdSpec.php
+++ b/spec/Talk/Entity/FeedbackIdSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Talk\Entity;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/Talk/Entity/TalkEntitySpec.php
+++ b/spec/Talk/Entity/TalkEntitySpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Talk\Entity;
 
 use Event\Entity\EventEntity;

--- a/spec/Talk/Entity/TalkIdSpec.php
+++ b/spec/Talk/Entity/TalkIdSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Talk\Entity;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/Talk/Handler/ClaimTalkHandlerSpec.php
+++ b/spec/Talk/Handler/ClaimTalkHandlerSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Talk\Handler;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/User/Command/RegisterUserSpec.php
+++ b/spec/User/Command/RegisterUserSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\User\Command;
 
 use Geo\Entity\CityId;

--- a/spec/User/Entity/UserEntitySpec.php
+++ b/spec/User/Entity/UserEntitySpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\User\Entity;
 
 use Geo\Entity\CityEntity;

--- a/spec/User/Entity/UserIdSpec.php
+++ b/spec/User/Entity/UserIdSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\User\Entity;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/User/Event/UserRegisteredSpec.php
+++ b/spec/User/Event/UserRegisteredSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\User\Event;
 
 use PhpSpec\ObjectBehavior;

--- a/spec/User/Hander/UserRegistrationHandlerSpec.php
+++ b/spec/User/Hander/UserRegistrationHandlerSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\User\Hander;
 
 use App\EventBus;

--- a/src/App/CommandBus.php
+++ b/src/App/CommandBus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use SimpleBus\SymfonyBridge\Bus\CommandBus as BaseCommandBus;

--- a/src/App/EventBus.php
+++ b/src/App/EventBus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use SimpleBus\SymfonyBridge\Bus\EventBus as BaseEventBus;

--- a/src/App/Kernel.php
+++ b/src/App/Kernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;

--- a/src/Event/Behat/EventDomainContext.php
+++ b/src/Event/Behat/EventDomainContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Event\Behat;
 
 use Behat\Behat\Context\Context;

--- a/src/Event/Controller/EventController.php
+++ b/src/Event/Controller/EventController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Event\Controller;
 
 use DateTime;

--- a/src/Event/Entity/EventEntity.php
+++ b/src/Event/Entity/EventEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Event\Entity;
 
 use DateTime;

--- a/src/Event/Entity/EventId.php
+++ b/src/Event/Entity/EventId.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Event\Entity;
 
 use Ramsey\Uuid\Uuid;

--- a/src/Event/Repository/EventRepository.php
+++ b/src/Event/Repository/EventRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Event\Repository;
 
 use Event\Entity\EventEntity;

--- a/src/Geo/Entity/CityEntity.php
+++ b/src/Geo/Entity/CityEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Geo\Entity;
 
 class CityEntity

--- a/src/Geo/Entity/CityId.php
+++ b/src/Geo/Entity/CityId.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Geo\Entity;
 
 use Ramsey\Uuid\Uuid;

--- a/src/Geo/Entity/CountryEntity.php
+++ b/src/Geo/Entity/CountryEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Geo\Entity;
 
 class CountryEntity

--- a/src/Geo/Entity/LocationEntity.php
+++ b/src/Geo/Entity/LocationEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Geo\Entity;
 
 class LocationEntity

--- a/src/Geo/Entity/LocationId.php
+++ b/src/Geo/Entity/LocationId.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Geo\Entity;
 
 use Ramsey\Uuid\Uuid;

--- a/src/Geo/Repository/CityRepository.php
+++ b/src/Geo/Repository/CityRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Geo\Repository;
 
 use Geo\Entity\CityEntity;

--- a/src/Organization/Behat/OrganizationDomainContext.php
+++ b/src/Organization/Behat/OrganizationDomainContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Organization\Behat;
 
 use Behat\Behat\Context\Context;

--- a/src/Organization/Command/JoinOrganization.php
+++ b/src/Organization/Command/JoinOrganization.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Organization\Command;
 
 use Organization\Entity\OrganizationId;

--- a/src/Organization/Controller/ClaimController.php
+++ b/src/Organization/Controller/ClaimController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Organization\Controller;
 
 use Doctrine\ORM\EntityManager;

--- a/src/Organization/Controller/OrganizationController.php
+++ b/src/Organization/Controller/OrganizationController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Organization\Controller;
 
 use Doctrine\ORM\EntityManager;

--- a/src/Organization/Controller/RsvpController.php
+++ b/src/Organization/Controller/RsvpController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Organization\Controller;
 
 use Doctrine\ORM\EntityManager;

--- a/src/Organization/Entity/ClaimEntity.php
+++ b/src/Organization/Entity/ClaimEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Organization\Entity;
 
 use Talk\Entity\TalkEntity;

--- a/src/Organization/Entity/ClaimId.php
+++ b/src/Organization/Entity/ClaimId.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Organization\Entity;
 
 use Ramsey\Uuid\Uuid;

--- a/src/Organization/Entity/OrganizationEntity.php
+++ b/src/Organization/Entity/OrganizationEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Organization\Entity;
 
 use DomainException;

--- a/src/Organization/Entity/OrganizationId.php
+++ b/src/Organization/Entity/OrganizationId.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Organization\Entity;
 
 use Ramsey\Uuid\Uuid;

--- a/src/Organization/Handler/JoinOrganizationHandler.php
+++ b/src/Organization/Handler/JoinOrganizationHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Organization\Handler;
 
 use Organization\Command\JoinOrganization;

--- a/src/Organization/Repository/ClaimRepository.php
+++ b/src/Organization/Repository/ClaimRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Organization\Repository;
 
 use Organization\Entity\OrganizationEntity;

--- a/src/Organization/Repository/OrganizationRepository.php
+++ b/src/Organization/Repository/OrganizationRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Organization\Repository;
 
 use Organization\Entity\OrganizationEntity;

--- a/src/Talk/Behat/TalkApplicationContext.php
+++ b/src/Talk/Behat/TalkApplicationContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Talk\Behat;
 
 use Behat\Behat\Context\Context;

--- a/src/Talk/Behat/TalkDomainContext.php
+++ b/src/Talk/Behat/TalkDomainContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Talk\Behat;
 
 use Behat\Behat\Context\Context;

--- a/src/Talk/Commmand/ClaimTalk.php
+++ b/src/Talk/Commmand/ClaimTalk.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Talk\Commmand;
 
 use Talk\Entity\TalkId;

--- a/src/Talk/Controller/TalkController.php
+++ b/src/Talk/Controller/TalkController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Talk\Controller;
 
 use Doctrine\ORM\EntityManager;

--- a/src/Talk/Entity/FeedbackEntity.php
+++ b/src/Talk/Entity/FeedbackEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Talk\Entity;
 
 use DateTime;

--- a/src/Talk/Entity/FeedbackId.php
+++ b/src/Talk/Entity/FeedbackId.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Talk\Entity;
 
 use Ramsey\Uuid\Uuid;

--- a/src/Talk/Entity/TalkEntity.php
+++ b/src/Talk/Entity/TalkEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Talk\Entity;
 
 use Event\Entity\EventEntity;

--- a/src/Talk/Entity/TalkId.php
+++ b/src/Talk/Entity/TalkId.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Talk\Entity;
 
 use Ramsey\Uuid\Uuid;

--- a/src/Talk/Exception/PendingClaimExistsException.php
+++ b/src/Talk/Exception/PendingClaimExistsException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Talk\Exception;
 
 use DomainException;

--- a/src/Talk/Exception/SpeakerAlreadySetException.php
+++ b/src/Talk/Exception/SpeakerAlreadySetException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Talk\Exception;
 
 use DomainException;

--- a/src/Talk/Handler/ClaimTalkHandler.php
+++ b/src/Talk/Handler/ClaimTalkHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Talk\Handler;
 
 use Talk\Commmand\ClaimTalk;

--- a/src/Talk/Repository/TalkRepository.php
+++ b/src/Talk/Repository/TalkRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Talk\Repository;
 
 use Talk\Entity\TalkEntity;

--- a/src/User/Behat/UserApplicationContext.php
+++ b/src/User/Behat/UserApplicationContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Behat;
 
 use App\EventBus;

--- a/src/User/Behat/UserDomainContext.php
+++ b/src/User/Behat/UserDomainContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Behat;
 
 use Behat\Behat\Context\Context;

--- a/src/User/Behat/UserFixturesContext.php
+++ b/src/User/Behat/UserFixturesContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Behat;
 
 use Behat\Behat\Context\Context;

--- a/src/User/Command/RegisterUser.php
+++ b/src/User/Command/RegisterUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Command;
 
 use Geo\Entity\CityId;

--- a/src/User/Entity/UserEntity.php
+++ b/src/User/Entity/UserEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Entity;
 
 use Geo\Entity\CityEntity;

--- a/src/User/Entity/UserId.php
+++ b/src/User/Entity/UserId.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Entity;
 
 use Ramsey\Uuid\Uuid;

--- a/src/User/Event/UserRegistered.php
+++ b/src/User/Event/UserRegistered.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Event;
 
 use User\Entity\UserId;

--- a/src/User/Hander/UserRegistrationHandler.php
+++ b/src/User/Hander/UserRegistrationHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Hander;
 
 use App\EventBus;

--- a/src/User/Repository/UserRepository.php
+++ b/src/User/Repository/UserRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace User\Repository;
 
 use User\Entity\UserEntity;

--- a/tests/Event/Repository/EventInMemoryRepository.php
+++ b/tests/Event/Repository/EventInMemoryRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Event\Repository;
 
 use Event\Entity\EventEntity;

--- a/tests/Geo/Repository/CityInMemoryRepository.php
+++ b/tests/Geo/Repository/CityInMemoryRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Geo\Repository;
 
 use Geo\Entity\CityEntity;

--- a/tests/Organization/Repository/OrganizationInMemoryRepository.php
+++ b/tests/Organization/Repository/OrganizationInMemoryRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Organization\Repository;
 
 use Organization\Entity\OrganizationEntity;

--- a/tests/Talk/Repository/TalkInMemoryRepository.php
+++ b/tests/Talk/Repository/TalkInMemoryRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Talk\Repository;
 
 use Talk\Entity\TalkEntity;

--- a/tests/User/Repository/UserInMemoryRepository.php
+++ b/tests/User/Repository/UserInMemoryRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\User\Repository;
 
 use User\Entity\UserEntity;


### PR DESCRIPTION
In order to be sure strict types are used properly we need to enforce that all files have `declare(strict_types=1)` in them.

This PR includes addition to php-cs-fixer config to run them and fix of all existing files missing them.


Closes #123