### PR TITLE
Save claimed talk using TalkRepository

### DIFF
--- a/spec/Talk/Handler/ClaimTalkHandlerSpec.php
+++ b/spec/Talk/Handler/ClaimTalkHandlerSpec.php
@@ -49,6 +49,8 @@ class ClaimTalkHandlerSpec extends ObjectBehavior
         $talk->claimTalk($claimer)
             ->shouldBeCalled();
 
+        $talkRepository->save($talk)->shouldBeCalled();
+
         $this->handle($command);
     }
 }

--- a/src/Talk/Handler/ClaimTalkHandler.php
+++ b/src/Talk/Handler/ClaimTalkHandler.php
@@ -27,5 +27,7 @@ class ClaimTalkHandler
         $claimer = $this->userRepository->load($command->getUserId());
 
         $talk->claimTalk($claimer);
+
+        $this->talkRepository->save($talk);
     }
 }


### PR DESCRIPTION
Commit a545b93692398269f2 forgot to add a call to TalkRepository
to save the claimed talk. This is a fix.

Note: is this a signal that we missed something in the tests?
Shouldn't have Behat scenarios caught this?