### PR TITLE
Instead of mocking current user, use transformation provider

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -3,6 +3,7 @@ default:
         organization:
             contexts:
                 - Organization\Behat\OrganizationDomainContext
+                - User\Behat\UserFixturesContext
             filters:
                 tags: "@organization"
         talk:

--- a/src/Event/Behat/EventDomainContext.php
+++ b/src/Event/Behat/EventDomainContext.php
@@ -12,7 +12,6 @@ use Geo\Entity\CityEntity;
 use Geo\Entity\LocationEntity;
 use Geo\Entity\LocationId;
 use Mockery;
-use Mockery\MockInterface;
 use Organization\Entity\OrganizationEntity;
 use Organization\Entity\OrganizationId;
 use User\Entity\UserEntity;
@@ -21,7 +20,7 @@ use Webmozart\Assert\Assert;
 
 class EventDomainContext implements Context
 {
-    /** @var UserEntity|MockInterface */
+    /** @var UserEntity */
     private $user;
     /** @var OrganizationEntity */
     private $organization;
@@ -31,9 +30,9 @@ class EventDomainContext implements Context
     /**
      * @Given I'am logged in as :name
      */
-    public function iamLoggedInAs()
+    public function iamLoggedInAs(UserEntity $user)
     {
-        $this->user = Mockery::mock(UserEntity::class);
+        $this->user = $user;
     }
 
     /**

--- a/src/Organization/Behat/OrganizationDomainContext.php
+++ b/src/Organization/Behat/OrganizationDomainContext.php
@@ -9,7 +9,6 @@ use Geo\Entity\CityEntity;
 use Geo\Entity\CityId;
 use Geo\Entity\CountryEntity;
 use Mockery;
-use Mockery\MockInterface;
 use Organization\Entity\OrganizationEntity;
 use Organization\Entity\OrganizationId;
 use User\Entity\UserEntity;
@@ -17,7 +16,7 @@ use Webmozart\Assert\Assert;
 
 class OrganizationDomainContext implements Context
 {
-    /** @var UserEntity|MockInterface */
+    /** @var UserEntity */
     private $user;
     /** @var OrganizationEntity */
     private $organization;
@@ -25,9 +24,9 @@ class OrganizationDomainContext implements Context
     /**
      * @Given I'am logged in as :name
      */
-    public function iamLoggedInAs()
+    public function iamLoggedInAs(UserEntity $user)
     {
-        $this->user = Mockery::mock(UserEntity::class);
+        $this->user = $user;
     }
 
     /**

--- a/src/Talk/Behat/TalkDomainContext.php
+++ b/src/Talk/Behat/TalkDomainContext.php
@@ -12,7 +12,6 @@ use Event\Entity\EventId;
 use Geo\Entity\CityEntity;
 use Geo\Entity\LocationEntity;
 use Mockery;
-use Mockery\MockInterface;
 use Organization\Entity\ClaimEntity;
 use Organization\Entity\OrganizationEntity;
 use Organization\Entity\OrganizationId;
@@ -26,7 +25,7 @@ use Webmozart\Assert\Assert;
  */
 class TalkDomainContext implements Context
 {
-    /** @var UserEntity|MockInterface */
+    /** @var UserEntity */
     private $user;
     /** @var OrganizationEntity */
     private $organization;
@@ -42,9 +41,9 @@ class TalkDomainContext implements Context
     /**
      * @Given I'am logged in as :name
      */
-    public function iamLoggedInAs()
+    public function iamLoggedInAs(UserEntity $user)
     {
-        $this->user = Mockery::mock(UserEntity::class);
+        $this->user = $user;
     }
 
     /**


### PR DESCRIPTION
In the beginning, we started with a mocked current user cause we had no user structure defined. As we brought in user transformer (method to provide a user based on their name) we can implement it on all of the places where we used mocks.