### PR TITLE
[#126] Remove unused Organization::addEvent

### DIFF
--- a/features/claim-talk.feature
+++ b/features/claim-talk.feature
@@ -10,24 +10,24 @@ Feature:
     And there is a talk "Something about nothing"
 
   Scenario: Speaker can claim unclaimed talk
-    Given I'am logged in as "Jo Johnson"
+    Given I am logged in as "Jo Johnson"
     When I claim "Something about nothing"
     Then I should have "Something about nothing" claimed
 
   Scenario: Talks with pending claims can not be claimed
     Given "Something about nothing" has a pending claim by "Jo Johnson"
-    And I'am logged in as "Alex Smith"
+    And I am logged in as "Alex Smith"
     When I claim "Something about nothing"
     Then I should see an error saying there is a pending claim on the talk
 
   Scenario: Talks with rejected claims can be claimed
     Given "Something about nothing" has a rejected claim by "Jo Johnson"
-    And I'am logged in as "Alex Smith"
+    And I am logged in as "Alex Smith"
     When I claim "Something about nothing"
     Then I should have "Something about nothing" claimed
 
   Scenario: Talks with speaker assigned can not be claimed
     Given "Something about nothing" has "Jo Johnson" assigned as speaker
-    And I'am logged in as "Alex Smith"
+    And I am logged in as "Alex Smith"
     When I claim "Something about nothing"
     Then I should see an error saying there speaker is already assigned

--- a/features/create-organization.feature
+++ b/features/create-organization.feature
@@ -5,17 +5,17 @@ Feature:
   I need to first create an organization
 
   Scenario: Create an organization
-    Given I'am logged in as "Alex Smith"
+    Given I am logged in as "Alex Smith"
     When I create "Local meetup" organization with description "Community of people doing ..." in "New York,US"
     Then there is new "Local meetup" organization
 
   Scenario: User that created new organization will be founder of the organization
-    Given I'am logged in as "Alex Smith"
+    Given I am logged in as "Alex Smith"
     When I create "Local meetup" organization with description "Community of people doing ..." in "New York,US"
     Then "Alex Smith" is founder of "Local meetup" organization
 
   Scenario: User that created new organization is automatically an organizer
-    Given I'am logged in as "Alex Smith"
+    Given I am logged in as "Alex Smith"
     When I create "Local meetup" organization with description "Community of people doing ..." in "New York,US"
     Then "Alex Smith" is organizer of "Local meetup" organization
 

--- a/features/join-organization.feature
+++ b/features/join-organization.feature
@@ -8,18 +8,18 @@ Feature:
     Given there is a "Local meetup" organization
 
   Scenario: User can join organization
-    Given I'am logged in as "Jo Johnson"
+    Given I am logged in as "Jo Johnson"
     When I join "Local meetup" organization
     Then I should be a member of "Local meetup" organization
 
   Scenario: Existing members can't join organization
-    Given I'am logged in as "Jo Johnson"
+    Given I am logged in as "Jo Johnson"
     And I'm a member of "Local meetup" organization
     When I try to join "Local meetup" organization
     Then I should see an error saying I'm already a member of the organization
 
   Scenario: Existing organizers can't join organization
-    Given I'am logged in as "Alex Smith"
+    Given I am logged in as "Alex Smith"
     And "Alex Smith" is an organizer
     When I try to join "Local meetup" organization
     Then I should see an error saying I'm already a member of the organization

--- a/features/organizer-can-create-event.feature
+++ b/features/organizer-can-create-event.feature
@@ -9,5 +9,5 @@ Feature:
 
   Scenario: Organizer can create event
     Given I'am logged in as "Jo Johnson"
-    When I create a new event with name "Some event" for organization "Local organization" with date "2018-04-24", description "Event description" in venue "Katran klub"
-    Then There is a new event with name "Some event" and venue "Katran klub" for organization "Local organization"
+    When I create a new event with title "Some event" for organization "Local organization" with date "2018-04-24", description "Event description" in venue "Katran klub, Zagreb, Croatia"
+    Then the new event has title "Some event", venue "Katran klub, Zagreb, Croatia", date "2018-04-24", description "Event description" and organization "Local organization"

--- a/features/organizer-can-create-event.feature
+++ b/features/organizer-can-create-event.feature
@@ -8,6 +8,6 @@ Feature:
     And user "Jo Johnson" is organizer of "Local organization" organization
 
   Scenario: Organizer can create event
-    Given I'am logged in as "Jo Johnson"
+    Given I am logged in as "Jo Johnson"
     When I create a new event with title "Some event" for organization "Local organization" with date "2018-04-24", description "Event description" in venue "Katran klub, Zagreb, Croatia"
     Then the new event has title "Some event", venue "Katran klub, Zagreb, Croatia", date "2018-04-24", description "Event description" and organization "Local organization"

--- a/features/rsvp-to-event.feature
+++ b/features/rsvp-to-event.feature
@@ -10,24 +10,24 @@ Feature:
     And "Jo Johnson" is a member of "Local meetup" organization
 
   Scenario: Member can RSVP Yes to an event
-    Given I'am logged in as "Jo Johnson"
+    Given I am logged in as "Jo Johnson"
     When I RSVP Yes to "March 2019 gathering"
     Then I will be on a list of interested members for "March 2019 gathering" event
 
   Scenario: Member can RSVP No to an event
-    Given I'am logged in as "Jo Johnson"
+    Given I am logged in as "Jo Johnson"
     When I RSVP No to "March 2019 gathering"
     Then I will be on a list of members not coming to "March 2019 gathering" event
 
   Scenario: Member can change RSVP from No to Yes
-    Given I'am logged in as "Jo Johnson"
+    Given I am logged in as "Jo Johnson"
     And I have RSVPed No to "March 2019 gathering" event
     When I change my "March 2019 gathering" RSVP to Yes
     Then I will be on a list of interested members for "March 2019 gathering" event
     And I will not be on a list of members not coming to "March 2019 gathering" event
 
   Scenario: Member can change RSVP from Yes to No
-    Given I'am logged in as "Jo Johnson"
+    Given I am logged in as "Jo Johnson"
     And I have RSVPed Yes to "March 2019 gathering" event
     When I change my "March 2019 gathering" RSVP to No
     Then I will be on a list of members not coming to "March 2019 gathering" event

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,6 @@ parameters:
 	    - '#Parameter \#4 \$founder of class Organization\\Entity\\OrganizationEntity constructor expects User\\Entity\\UserEntity, Mockery\\MockInterface|User\\Entity\\UserEntity given.#'
 	    - '#Parameter \#5 \$hometown of class Organization\\Entity\\OrganizationEntity constructor expects Geo\\Entity\\CityEntity, Mockery\\MockInterface given.#'
 	    - '#Parameter \#7 \$city of class User\\Entity\\UserEntity constructor expects Geo\\Entity\\CityEntity, Mockery\\MockInterface given.#'
-	    - '#Parameter \#3 \$city of class Geo\\Entity\\LocationEntity constructor expects Geo\\Entity\\CityEntity, Mockery\\MockInterface given.#'
 	    - '#Parameter \#6 \$organization of class Event\\Entity\\EventEntity constructor expects Organization\\Entity\\OrganizationEntity, Mockery\\MockInterface given.#'
 
 

--- a/spec/Event/Entity/EventEntitySpec.php
+++ b/spec/Event/Entity/EventEntitySpec.php
@@ -37,12 +37,13 @@ class EventEntitySpec extends ObjectBehavior
         $this->getId()->shouldReturn($id);
     }
 
-    public function it_exposes_event_details(DateTime $eventDate, LocationEntity $location)
+    public function it_exposes_event_details(DateTime $eventDate, LocationEntity $location, OrganizationEntity $organization)
     {
         $this->getEventDate()->shouldReturn($eventDate);
         $this->getTitle()->shouldReturn('Event title');
         $this->getDescription()->shouldReturn('Event description');
         $this->getLocation()->shouldReturn($location);
+        $this->getOrganization()->shouldReturn($organization);
     }
 
     public function it_will_add_attendee_to_event(UserEntity $attendee)

--- a/src/Event/Behat/EventDomainContext.php
+++ b/src/Event/Behat/EventDomainContext.php
@@ -34,7 +34,7 @@ class EventDomainContext implements Context
     private $event;
 
     /**
-     * @Given I'am logged in as :name
+     * @Given I am logged in as :name
      */
     public function iamLoggedInAs(UserEntity $user)
     {
@@ -51,7 +51,7 @@ class EventDomainContext implements Context
     }
 
     /**
-     * @Given I'am organizer
+     * @Given I am organizer
      */
     public function iamOrganizer()
     {

--- a/src/Event/Entity/EventEntity.php
+++ b/src/Event/Entity/EventEntity.php
@@ -88,7 +88,7 @@ class EventEntity
 
     public function getOrganization(): OrganizationEntity
     {
-        //@TODO;
+        return $this->organization;
     }
 
     public function addAttendee(UserEntity $attendee)

--- a/src/Organization/Behat/OrganizationDomainContext.php
+++ b/src/Organization/Behat/OrganizationDomainContext.php
@@ -20,7 +20,7 @@ class OrganizationDomainContext implements Context
     private $organization;
 
     /**
-     * @Given I'am logged in as :name
+     * @Given I am logged in as :name
      */
     public function iamLoggedInAs(UserEntity $user)
     {

--- a/src/Organization/Entity/OrganizationEntity.php
+++ b/src/Organization/Entity/OrganizationEntity.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Organization\Entity;
 
 use DomainException;
-use Event\Entity\EventEntity;
 use Geo\Entity\CityEntity;
 use User\Entity\UserEntity;
 
@@ -41,11 +40,6 @@ class OrganizationEntity
      */
     private $hometown;
 
-    /**
-     * @var EventEntity[]
-     */
-    private $events;
-
     public function __construct(
         OrganizationId $id,
         string $title,
@@ -59,7 +53,6 @@ class OrganizationEntity
         $this->founder      = $founder;
         $this->members      = [];
         $this->hometown     = $hometown;
-        $this->events       = [];
         $this->organizers[] = $founder;
     }
 
@@ -148,19 +141,8 @@ class OrganizationEntity
         return $this->approved;
     }
 
-    /** @SuppressWarnings("PHPMD.UnusedFormalParameter") */
-    public function addEvent(EventEntity $event)
-    {
-        $this->events[] = $event;
-    }
-
     public function getHometown()
     {
         return $this->hometown;
-    }
-
-    public function getEvents(): array
-    {
-        return $this->events;
     }
 }

--- a/src/Talk/Behat/TalkApplicationContext.php
+++ b/src/Talk/Behat/TalkApplicationContext.php
@@ -97,7 +97,7 @@ class TalkApplicationContext implements Context
     }
 
     /**
-     * @Given I'am logged in as :name
+     * @Given I am logged in as :name
      */
     public function iamLoggedInAs(UserEntity $user)
     {

--- a/src/Talk/Behat/TalkDomainContext.php
+++ b/src/Talk/Behat/TalkDomainContext.php
@@ -37,7 +37,7 @@ class TalkDomainContext implements Context
     private $exception;
 
     /**
-     * @Given I'am logged in as :name
+     * @Given I am logged in as :name
      */
     public function iamLoggedInAs(UserEntity $user)
     {

--- a/src/User/Behat/UserApplicationContext.php
+++ b/src/User/Behat/UserApplicationContext.php
@@ -68,7 +68,7 @@ class UserApplicationContext implements Context
     }
 
     /**
-     * @Given I'am logged in as :name
+     * @Given I am logged in as :name
      */
     public function iamLoggedInAs(UserEntity $user)
     {

--- a/src/User/Behat/UserDomainContext.php
+++ b/src/User/Behat/UserDomainContext.php
@@ -24,7 +24,7 @@ class UserDomainContext implements Context
     private $exception;
 
     /**
-     * @Given I'am logged in as :name
+     * @Given I am logged in as :name
      */
     public function iamLoggedInAs(UserEntity $user)
     {


### PR DESCRIPTION
Removing unused Organizatoin::addEvent requires some refactoring:
- refactor EventDomainContext to include Transformer functions for
Organization and venue string to location
- reword scenario steps to match actual task

Closes #126 