### PR TITLE
Issue #170 - Rename entity examples in Behat scenarios

### DIFF
--- a/features/claim-talk.feature
+++ b/features/claim-talk.feature
@@ -5,29 +5,29 @@ Feature:
   I need to claim a talk
 
   Background:
-    Given there is a "Local meetup" organization
+    Given there is a "New York Developer Ninjas" organization
     And "March 2019 gathering" is scheduled for "2019-03-07"
-    And there is a talk "Something about nothing"
+    And there is a talk "Joys of Programming"
 
   Scenario: Speaker can claim unclaimed talk
     Given I am logged in as "Jo Johnson"
-    When I claim "Something about nothing"
-    Then I should have "Something about nothing" claimed
+    When I claim "Joys of Programming"
+    Then I should have "Joys of Programming" claimed
 
   Scenario: Talks with pending claims can not be claimed
-    Given "Something about nothing" has a pending claim by "Jo Johnson"
+    Given "Joys of Programming" has a pending claim by "Jo Johnson"
     And I am logged in as "Alex Smith"
-    When I claim "Something about nothing"
+    When I claim "Joys of Programming"
     Then I should see an error saying there is a pending claim on the talk
 
   Scenario: Talks with rejected claims can be claimed
-    Given "Something about nothing" has a rejected claim by "Jo Johnson"
+    Given "Joys of Programming" has a rejected claim by "Jo Johnson"
     And I am logged in as "Alex Smith"
-    When I claim "Something about nothing"
-    Then I should have "Something about nothing" claimed
+    When I claim "Joys of Programming"
+    Then I should have "Joys of Programming" claimed
 
   Scenario: Talks with speaker assigned can not be claimed
-    Given "Something about nothing" has "Jo Johnson" assigned as speaker
+    Given "Joys of Programming" has "Jo Johnson" assigned as speaker
     And I am logged in as "Alex Smith"
-    When I claim "Something about nothing"
+    When I claim "Joys of Programming"
     Then I should see an error saying there speaker is already assigned

--- a/features/create-organization.feature
+++ b/features/create-organization.feature
@@ -6,18 +6,18 @@ Feature:
 
   Scenario: Create an organization
     Given I am logged in as "Alex Smith"
-    When I create "Local meetup" organization with description "Community of people doing ..." in "New York,US"
-    Then there is new "Local meetup" organization
+    When I create "New York Developer Ninjas" organization with description "Community of people doing ..." in "New York,US"
+    Then there is new "New York Developer Ninjas" organization
 
   Scenario: User that created new organization will be founder of the organization
     Given I am logged in as "Alex Smith"
-    When I create "Local meetup" organization with description "Community of people doing ..." in "New York,US"
-    Then "Alex Smith" is founder of "Local meetup" organization
+    When I create "New York Developer Ninjas" organization with description "Community of people doing ..." in "New York,US"
+    Then "Alex Smith" is founder of "New York Developer Ninjas" organization
 
   Scenario: User that created new organization is automatically an organizer
     Given I am logged in as "Alex Smith"
-    When I create "Local meetup" organization with description "Community of people doing ..." in "New York,US"
-    Then "Alex Smith" is organizer of "Local meetup" organization
+    When I create "New York Developer Ninjas" organization with description "Community of people doing ..." in "New York,US"
+    Then "Alex Smith" is organizer of "New York Developer Ninjas" organization
 
 
 

--- a/features/join-organization.feature
+++ b/features/join-organization.feature
@@ -5,22 +5,22 @@ Feature:
   I need to join organization
 
   Background:
-    Given there is a "Local meetup" organization
+    Given there is a "New York Developer Ninjas" organization
 
   Scenario: User can join organization
     Given I am logged in as "Jo Johnson"
-    When I join "Local meetup" organization
-    Then I should be a member of "Local meetup" organization
+    When I join "New York Developer Ninjas" organization
+    Then I should be a member of "New York Developer Ninjas" organization
 
   Scenario: Existing members can't join organization
     Given I am logged in as "Jo Johnson"
-    And I'm a member of "Local meetup" organization
-    When I try to join "Local meetup" organization
+    And I'm a member of "New York Developer Ninjas" organization
+    When I try to join "New York Developer Ninjas" organization
     Then I should see an error saying I'm already a member of the organization
 
   Scenario: Existing organizers can't join organization
     Given I am logged in as "Alex Smith"
     And "Alex Smith" is an organizer
-    When I try to join "Local meetup" organization
+    When I try to join "New York Developer Ninjas" organization
     Then I should see an error saying I'm already a member of the organization
     

--- a/features/managing-new-organizations.feature
+++ b/features/managing-new-organizations.feature
@@ -5,13 +5,13 @@ Feature:
   I need to approve/reject new organizations
 
   Scenario: Approve new organization
-    Given new "Local meetup" organization was created
-    When I approve "Local meetup" organization
-    Then "Local meetup" organization is approved
+    Given new "New York Developer Ninjas" organization was created
+    When I approve "New York Developer Ninjas" organization
+    Then "New York Developer Ninjas" organization is approved
 
   Scenario: Reject new organization
-    Given new "Local meetup" organization was created
-    When I reject "Local meetup" organization
-    Then "Local meetup" organization is rejected
+    Given new "New York Developer Ninjas" organization was created
+    When I reject "New York Developer Ninjas" organization
+    Then "New York Developer Ninjas" organization is rejected
 
 

--- a/features/organizer-can-create-event.feature
+++ b/features/organizer-can-create-event.feature
@@ -4,10 +4,10 @@ Feature:
   I can create event
 
   Background:
-    Given there is a 'Local organization' organization
-    And user "Jo Johnson" is organizer of "Local organization" organization
+    Given there is a 'New York Developer Ninjas' organization
+    And user "Alex Smith" is organizer of "New York Developer Ninjas" organization
 
   Scenario: Organizer can create event
     Given I am logged in as "Jo Johnson"
-    When I create a new event with title "Some event" for organization "Local organization" with date "2018-04-24", description "Event description" in venue "Katran klub, Zagreb, Croatia"
-    Then the new event has title "Some event", venue "Katran klub, Zagreb, Croatia", date "2018-04-24", description "Event description" and organization "Local organization"
+    When I create a new event with title "Spring Drink-up" for organization "New York Developer Ninjas" with date "2018-04-24", description "During our spring break, we'll organize drink-ups only." in venue "Bar Goto, New York, United States"
+    Then the new event has title "Spring Drink-up", venue "Bar Goto, New York, United States", date "2018-04-24", description "During our spring break, we'll organize drink-ups only." and organization "New York Developer Ninjas"

--- a/features/rsvp-to-event.feature
+++ b/features/rsvp-to-event.feature
@@ -5,9 +5,9 @@ Feature:
   I need to RSVP
 
   Background:
-    Given there is a "Local meetup" organization
+    Given there is a "New York Developer Ninjas" organization
     And "March 2019 gathering" is scheduled for "2019-03-07"
-    And "Jo Johnson" is a member of "Local meetup" organization
+    And "Jo Johnson" is a member of "New York Developer Ninjas" organization
 
   Scenario: Member can RSVP Yes to an event
     Given I am logged in as "Jo Johnson"

--- a/src/Event/Behat/EventDomainContext.php
+++ b/src/Event/Behat/EventDomainContext.php
@@ -214,11 +214,11 @@ class EventDomainContext implements Context
         $city    = Mockery::mock(CityEntity::class);
 
         switch ($orgName) {
-            case 'Local meetup':
+            case 'New York Developer Ninjas':
                 return new OrganizationEntity(
                     new OrganizationId('1d535d47-a72c-4294-bbe7-6ee2d5b6e3fb'),
                     $orgName,
-                    'We are a small group of ...',
+                    'Community of people doing ...',
                     $founder,
                     $city
                 );

--- a/src/Organization/Behat/OrganizationFixturesContext.php
+++ b/src/Organization/Behat/OrganizationFixturesContext.php
@@ -22,7 +22,7 @@ class OrganizationFixturesContext implements Context
         $city    = Mockery::mock(CityEntity::class);
 
         switch ($orgName) {
-            case 'Local meetup':
+            case 'New York Developer Ninjas':
                 return new OrganizationEntity(
                     new OrganizationId('1d535d47-a72c-4294-bbe7-6ee2d5b6e3fb'),
                     $orgName,

--- a/src/Talk/Behat/TalkApplicationContext.php
+++ b/src/Talk/Behat/TalkApplicationContext.php
@@ -203,7 +203,7 @@ class TalkApplicationContext implements Context
         $event = $this->event;
 
         switch ($title) {
-            case 'Something about nothing':
+            case 'Joys of Programming':
                 return new TalkEntity(new TalkId('default-talk-id'), $event, $title, 'description', 'speaker name');
         }
     }

--- a/src/User/Behat/UserApplicationContext.php
+++ b/src/User/Behat/UserApplicationContext.php
@@ -89,7 +89,7 @@ class UserApplicationContext implements Context
      */
     public function isAnOrganizer(UserEntity $user)
     {
-        $organization = $this->organizationRepository->loadByTitle('Local meetup');
+        $organization = $this->organizationRepository->loadByTitle('New York Developer Ninjas');
 
         $organization->addOrganizer($user);
     }


### PR DESCRIPTION
In order to ease the understanding of connections between scenarios,
we need consistent naming of various entities throughout all the
examples.

This will even out all the entity names (for organization, event, talk, venue), but to be fully consistent, I've opened issue #172.

Additionally, I think we should start thinking about refactoring some of the Behat Context files - it's been fun working on this issue, but it's also been a pain hunting through a bunch of files that are acting like some kind of factory for organization, talk, or event objects.

Any suggestions (other than "go for it - refactor") or tips/pointers?


---------------
Closes #170 