### PR TITLE
[Exploratory] Force ansi output through Phing commands

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -19,11 +19,11 @@
     </target>
 
     <target name="phpspec" description="Run phpspec">
-        <exec command="./vendor/bin/phpspec run" passthru="true" checkreturn="true"/>
+        <exec command="./vendor/bin/phpspec run --ansi" passthru="true" checkreturn="true"/>
     </target>
 
     <target name="behat" description="Run behat">
-        <exec command="./vendor/bin/behat" passthru="true" checkreturn="true"/>
+        <exec command="./vendor/bin/behat --colors" passthru="true" checkreturn="true"/>
     </target>
 
     <target name="phpunit" description="Run phpunit">
@@ -31,7 +31,8 @@
     </target>
 
     <target name="phpstan" description="Run phpstan">
-        <exec command="./vendor/bin/phpstan --memory-limit=-1 analyse -l 7 -c phpstan.neon src tests" passthru="true" checkreturn="true"/>
+        <exec command="./vendor/bin/phpstan --ansi --memory-limit=-1 analyse -l 7 -c phpstan.neon src tests"
+              passthru="true" checkreturn="true"/>
     </target>
 
     <target name="php-cs-fixer-check" description="Run php-cs-fixer check">


### PR DESCRIPTION
By default, Phing interprets it's tasks' output differently than it
would be handled by the STDOUT.

PhpSpec, PhpStan, and Behat support forced ansi output, which enables
output to be formatted and displayed in it's original state when
handled by Phing.

This will basically provide original output formatting to be returned
from Phing when running these commands.

(it's depressing and cold, and I like my output colored)

(if someone knows what's **REALLY** going on with output when piped through Phing, i.e. why colors are being stripped and PhpStan's progress bar gets split in multi-line instead of being displayed as a single progress bar, let me know - I **REALLY** want to know!) 